### PR TITLE
feat(parser): Add func return types

### DIFF
--- a/ast/dump.go
+++ b/ast/dump.go
@@ -54,9 +54,29 @@ func (d *dumper) node(n any, indent int) {
 		} else {
 			for _, p := range v.Params {
 				d.line(indent+2, "Param")
-				d.kv(indent+3, "Function", p.Name)
+				d.kv(indent+3, "Ident", p.Name)
 				d.line(indent+3, "Type")
 				d.typ(p.Type, indent+4)
+			}
+		}
+
+		if len(v.Results.List) > 0 {
+			d.line(indent+1, "Results")
+			if v.Results.LParen != (token.Token{}) {
+				d.kv(indent+2, "LParent", v.Results.LParen)
+			}
+
+			for _, p := range v.Results.List {
+				d.line(indent+3, "Param")
+				if p.Name != (token.Token{}) {
+					d.kv(indent+4, "Ident", p.Name)
+				}
+				d.line(indent+4, "Type")
+				d.typ(p.Type, indent+5)
+			}
+
+			if v.Results.RParen != (token.Token{}) {
+				d.kv(indent+2, "RParent", v.Results.RParen)
 			}
 		}
 

--- a/ast/types.go
+++ b/ast/types.go
@@ -22,16 +22,23 @@ type File struct {
 
 // FuncDecl holds function parsed content
 type FuncDecl struct {
-	FuncKW token.Token
-	Name   token.Token
-	Params []Param
-	Body   *BlockStmt
+	FuncKW  token.Token
+	Name    token.Token
+	Params  []Param
+	Results ReturnTypes
+	Body    *BlockStmt
 }
 
 // Params holds func parameter
 type Param struct {
 	Name token.Token
 	Type Type
+}
+
+type ReturnTypes struct {
+	LParen token.Token
+	List   []Param
+	RParen token.Token
 }
 
 // BlockStmt holds content between curly braces

--- a/parser/parser_common_test.go
+++ b/parser/parser_common_test.go
@@ -178,4 +178,15 @@ func TestParser_parse_common(t *testing.T) {
 		parse.position = len(lex.Tokens)
 		assert.Equal(false, parse.lookForInSwitchCaseHeader(token.Comma))
 	})
+
+	t.Run("peek_next_eof", func(t *testing.T) {
+		input := "main"
+
+		lex := lexer.New([]byte(input))
+		parse := New(lex.Tokens)
+		parse.position = len(input)
+		result := parse.peekNext(parse.position + 1)
+
+		assert.Equal(token.EOF, result.Kind)
+	})
 }

--- a/parser/parser_file_test.go
+++ b/parser/parser_file_test.go
@@ -181,17 +181,17 @@ func TestParser_parse_file(t *testing.T) {
    Name: "x" @3:6 (kind=3)
    Params
     Param
-     Function: "a" @3:8 (kind=3)
+     Ident: "a" @3:8 (kind=3)
      Type
       NameType
        Name: "int" @3:10 (kind=12)
     Param
-     Function: "b" @3:15 (kind=3)
+     Ident: "b" @3:15 (kind=3)
      Type
       NameType
        Name: "string" @3:17 (kind=24)
     Param
-     Function: "c" @3:25 (kind=3)
+     Ident: "c" @3:25 (kind=3)
      Type
       NameType
        Name: "string" @3:27 (kind=3)
@@ -283,7 +283,7 @@ func TestParser_parse_file(t *testing.T) {
 		assert.Greater(len(parser.errors), 0)
 	})
 
-	t.Run("bad_x3", func(t *testing.T) {
+	t.Run("bad_x4", func(t *testing.T) {
 		input := []token.Token{
 			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
 			{Kind: token.Ident, Value: "dummy", Line: 1, Column: 9},

--- a/parser/parser_func_decl_test.go
+++ b/parser/parser_func_decl_test.go
@@ -1,0 +1,661 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/orilang/gori/ast"
+	"github.com/orilang/gori/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParser_func_decl(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("return_types_x1", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 14},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		result := `File
+ Package: "package" @1:1 (kind=8)
+ Name: "main" @1:9 (kind=3)
+ Decls
+  FuncDecl
+   Function: "func" @3:1 (kind=10)
+   Name: "x" @3:6 (kind=3)
+   Params
+    (none)
+   Results
+     Param
+      Type
+       NameType
+        Name: "int" @3:10 (kind=12)
+   Body
+`
+		assert.Equal(result, ast.Dump(pr))
+		assert.Equal(0, len(parser.errors))
+	})
+
+	t.Run("return_types_x2", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 14},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 15},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 19},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 20},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		result := `File
+ Package: "package" @1:1 (kind=8)
+ Name: "main" @1:9 (kind=3)
+ Decls
+  FuncDecl
+   Function: "func" @3:1 (kind=10)
+   Name: "x" @3:6 (kind=3)
+   Params
+    (none)
+   Results
+    LParent: "(" @3:9 (kind=39)
+     Param
+      Type
+       NameType
+        Name: "int" @3:10 (kind=12)
+     Param
+      Type
+       NameType
+        Name: "int" @3:15 (kind=12)
+    RParent: ")" @3:19 (kind=40)
+   Body
+`
+		assert.Equal(result, ast.Dump(pr))
+		assert.Equal(0, len(parser.errors))
+	})
+
+	t.Run("return_types_x3", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 19},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		result := `File
+ Package: "package" @1:1 (kind=8)
+ Name: "main" @1:9 (kind=3)
+ Decls
+  FuncDecl
+   Function: "func" @3:1 (kind=10)
+   Name: "x" @3:6 (kind=3)
+   Params
+    (none)
+   Results
+    LParent: "(" @3:9 (kind=39)
+     Param
+      Ident: "a" @3:10 (kind=3)
+      Type
+       NameType
+        Name: "int" @3:12 (kind=12)
+     Param
+      Ident: "b" @3:17 (kind=3)
+      Type
+       NameType
+        Name: "int" @3:19 (kind=12)
+    RParent: ")" @3:20 (kind=40)
+   Body
+`
+		assert.Equal(result, ast.Dump(pr))
+		assert.Equal(0, len(parser.errors))
+	})
+
+	t.Run("return_types_x4", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 11},
+			{Kind: token.RBrace, Value: "}", Line: 3, Column: 12},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		result := `File
+ Package: "package" @1:1 (kind=8)
+ Name: "main" @1:9 (kind=3)
+ Decls
+  FuncDecl
+   Function: "func" @3:1 (kind=10)
+   Name: "x" @3:6 (kind=3)
+   Params
+    (none)
+   Body
+`
+		assert.Equal(result, ast.Dump(pr))
+		assert.Equal(0, len(parser.errors))
+	})
+
+	t.Run("return_types_x5", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.Ident, Value: "z", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.Ident, Value: "z", Line: 3, Column: 19},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		result := `File
+ Package: "package" @1:1 (kind=8)
+ Name: "main" @1:9 (kind=3)
+ Decls
+  FuncDecl
+   Function: "func" @3:1 (kind=10)
+   Name: "x" @3:6 (kind=3)
+   Params
+    (none)
+   Results
+    LParent: "(" @3:9 (kind=39)
+     Param
+      Ident: "a" @3:10 (kind=3)
+      Type
+       NameType
+        Name: "z" @3:12 (kind=3)
+     Param
+      Ident: "b" @3:17 (kind=3)
+      Type
+       NameType
+        Name: "z" @3:19 (kind=3)
+    RParent: ")" @3:20 (kind=40)
+   Body
+`
+		assert.Equal(result, ast.Dump(pr))
+		assert.Equal(0, len(parser.errors))
+	})
+
+	t.Run("bad_return_types_x1", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 14},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x2", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 14},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 15},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 16},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x3", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x4", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 10},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 11},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 12},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x5", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 10},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 11},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 18},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 19},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 20},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x6", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 10},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 11},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 18},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 19},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 20},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x7", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 9},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 10},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 11},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 12},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x8", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 11},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 18},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 19},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 20},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 21},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x9", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 11},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 19},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 20},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 21},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 22},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 23},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x10", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 11},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 19},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 20},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 21},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 22},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 23},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x11", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 12},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.KWReturn, Value: "return", Line: 3, Column: 19},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x12", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.KWReturn, Value: "return", Line: 3, Column: 19},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 21},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 22},
+			{Kind: token.KWReturn, Value: "return", Line: 3, Column: 24},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 25},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 26},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x13", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.KWStruct, Value: "struct", Line: 3, Column: 10},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 14},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x14", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 14},
+			{Kind: token.KWStruct, Value: "struct", Line: 3, Column: 16},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 24},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 25},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x15", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.KWStruct, Value: "struct", Line: 3, Column: 16},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 24},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 25},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x16", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 10},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 14},
+			{Kind: token.KWInt, Value: "int", Line: 3, Column: 16},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 17},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 24},
+			{Kind: token.LBrace, Value: "{", Line: 3, Column: 25},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+
+	t.Run("bad_return_types_x17", func(t *testing.T) {
+		input := []token.Token{
+			{Kind: token.KWPackage, Value: "package", Line: 1, Column: 1},
+			{Kind: token.Ident, Value: "main", Line: 1, Column: 9},
+
+			{Kind: token.KWFunc, Value: "func", Line: 3, Column: 1},
+			{Kind: token.Ident, Value: "x", Line: 3, Column: 6},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 7},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 8},
+			{Kind: token.LParen, Value: "(", Line: 3, Column: 9},
+			{Kind: token.Ident, Value: "a", Line: 3, Column: 10},
+			{Kind: token.Comma, Value: ",", Line: 3, Column: 16},
+			{Kind: token.Ident, Value: "b", Line: 3, Column: 17},
+			{Kind: token.Ident, Value: "z", Line: 3, Column: 19},
+			{Kind: token.RParen, Value: ")", Line: 3, Column: 20},
+			{Kind: token.LBrace, Value: "{", Line: 4, Column: 21},
+			{Kind: token.RBrace, Value: "}", Line: 4, Column: 15},
+			{Kind: token.EOF, Value: "", Line: 5, Column: 1},
+		}
+
+		parser := New(input)
+		pr := parser.ParseFile()
+		assert.NotNil(pr)
+		assert.Greater(len(parser.errors), 0)
+	})
+}

--- a/parser/parser_inc_dec_stmt_test.go
+++ b/parser/parser_inc_dec_stmt_test.go
@@ -84,7 +84,7 @@ func TestParser_inc_dec_stmt(t *testing.T) {
    Name: "x" @3:6 (kind=3)
    Params
     Param
-     Function: "a" @3:8 (kind=3)
+     Ident: "a" @3:8 (kind=3)
      Type
       NameType
        Name: "z" @3:10 (kind=3)
@@ -139,7 +139,7 @@ func TestParser_inc_dec_stmt(t *testing.T) {
    Name: "x" @3:6 (kind=3)
    Params
     Param
-     Function: "a" @3:8 (kind=3)
+     Ident: "a" @3:8 (kind=3)
      Type
       NameType
        Name: "z" @3:10 (kind=3)

--- a/parser/parser_stmt_test.go
+++ b/parser/parser_stmt_test.go
@@ -89,7 +89,7 @@ func TestParser_stmt(t *testing.T) {
    Name: "x" @3:6 (kind=3)
    Params
     Param
-     Function: "a" @3:8 (kind=3)
+     Ident: "a" @3:8 (kind=3)
      Type
       NameType
        Name: "z" @3:10 (kind=3)
@@ -148,7 +148,7 @@ func TestParser_stmt(t *testing.T) {
    Name: "x" @3:6 (kind=3)
    Params
     Param
-     Function: "a" @3:8 (kind=3)
+     Ident: "a" @3:8 (kind=3)
      Type
       NameType
        Name: "z" @3:10 (kind=3)

--- a/token/keywords.go
+++ b/token/keywords.go
@@ -127,3 +127,40 @@ var incDec = map[Kind]bool{
 	PPlus:  true,
 	MMinus: true,
 }
+
+var varConstTypes = map[Kind]bool{
+	Ident:       true,
+	KWInt:       true,
+	KWInt8:      true,
+	KWInt32:     true,
+	KWInt64:     true,
+	KWUint:      true,
+	KWUint8:     true,
+	KWUint32:    true,
+	KWUint64:    true,
+	KWFloat:     true,
+	KWFloat32:   true,
+	KWFloat64:   true,
+	KWString:    true,
+	KWBool:      true,
+	KWInterface: true,
+}
+
+var funcParamTypes = map[Kind]bool{
+	Ident:       true,
+	KWInt:       true,
+	KWInt8:      true,
+	KWInt32:     true,
+	KWInt64:     true,
+	KWUint:      true,
+	KWUint8:     true,
+	KWUint32:    true,
+	KWUint64:    true,
+	KWFloat:     true,
+	KWFloat32:   true,
+	KWFloat64:   true,
+	KWString:    true,
+	KWBool:      true,
+	KWInterface: true,
+	KWFunc:      true,
+}

--- a/token/token.go
+++ b/token/token.go
@@ -54,3 +54,13 @@ func IsRangeForAssignment(k Kind) bool {
 func IsIncDec(k Kind) bool {
 	return incDec[k]
 }
+
+// IsVarConstTypes returns true when the provided kind is found is the list
+func IsVarConstTypes(k Kind) bool {
+	return varConstTypes[k]
+}
+
+// IsFuncParamTypes returns true when the provided kind is found is the list
+func IsFuncParamTypes(k Kind) bool {
+	return funcParamTypes[k]
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -208,4 +208,44 @@ func TestToken(t *testing.T) {
 			assert.Equal(tc.expected, IsIncDec(tc.input))
 		}
 	})
+
+	t.Run("is_var_const_types", func(t *testing.T) {
+		tests := []struct {
+			input    Kind
+			expected bool
+		}{
+			{
+				input:    Ident,
+				expected: true,
+			},
+			{
+				input:    KWReturn,
+				expected: false,
+			},
+		}
+
+		for _, tc := range tests {
+			assert.Equal(tc.expected, IsVarConstTypes(tc.input))
+		}
+	})
+
+	t.Run("is_return_types", func(t *testing.T) {
+		tests := []struct {
+			input    Kind
+			expected bool
+		}{
+			{
+				input:    KWFunc,
+				expected: true,
+			},
+			{
+				input:    KWReturn,
+				expected: false,
+			},
+		}
+
+		for _, tc := range tests {
+			assert.Equal(tc.expected, IsFuncParamTypes(tc.input))
+		}
+	})
 }


### PR DESCRIPTION
Related to github issue #17

Globally for funcs, parameters and return types FORBID the usage to grouped-parameter syntax.
This means: `func(a,b,c int) (d,e,f int) {}` won't be supported.
It's a practicle sugar syntax but you can:
- end up with a long list of parameters
- some times not clear about the type
- produce long diff
- difficult/unclear to catch what parameter is missing

So for all of those reasons and many more this sugar syntax won't be supported